### PR TITLE
Split `dev-server` into `dev-server` and `hot`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "webpack-config-dev-server": "^0.1.0",
     "webpack-config-entry": "^0.1.0",
     "webpack-config-expose": "^0.1.1",
+    "webpack-config-hot": "^0.1.0",
     "webpack-config-json": "^0.1.1",
     "webpack-config-optimize": "^0.1.0",
     "webpack-config-postcss": "^0.1.6",

--- a/packages/webpack-config-dev-server/src/dev-server.webpack.config.js
+++ b/packages/webpack-config-dev-server/src/dev-server.webpack.config.js
@@ -1,4 +1,3 @@
-import { HotModuleReplacementPlugin, NoErrorsPlugin } from 'webpack';
 import { runtime } from 'webpack-udev-server';
 
 function inject(entries, module) {
@@ -16,7 +15,7 @@ function inject(entries, module) {
   throw new TypeError();
 }
 
-export default function devServer({ entry, target, hot }) {
+export default function devServer({ entry, target, hot = process.env.HOT }) {
   const env = process.env.NODE_ENV || 'development';
 
   // Don't use for anything but development.
@@ -30,12 +29,5 @@ export default function devServer({ entry, target, hot }) {
       entry,
       runtime({ target, hot })
     ),
-    plugins: hot ? [
-      // Add webpack's HMR runtime.
-      new HotModuleReplacementPlugin(),
-
-      // Don't generate bundles with errors so HMR doesn't bomb the app.
-      new NoErrorsPlugin(),
-    ] : [ ],
   };
 }

--- a/packages/webpack-config-hot/.babelrc
+++ b/packages/webpack-config-hot/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "metalab"
+  ]
+}

--- a/packages/webpack-config-hot/README.md
+++ b/packages/webpack-config-hot/README.md
@@ -1,0 +1,11 @@
+# webpack-config-hot
+
+Allow for hot module replacement in [webpack].
+
+```javascript
+import hot from 'webpack-config-hot';
+
+partial(config, hot);
+```
+
+[webpack]: https://webpack.github.io

--- a/packages/webpack-config-hot/package.json
+++ b/packages/webpack-config-hot/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "webpack-config-hot",
+  "version": "0.1.0",
+  "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
+  "repository": "izaakschroeder/webpack-config-metalab",
+  "license": "CC0-1.0",
+  "main": "dist/hot.webpack.config.js",
+  "scripts": {
+    "prepublish": "./node_modules/.bin/babel -d dist src"
+  },
+  "peerDependencies": {
+    "webpack": "*",
+    "webpack-udev-server": "*"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.0.0",
+    "babel-preset-metalab": "^0.1.1"
+  }
+}

--- a/packages/webpack-config-hot/src/hot.webpack.config.js
+++ b/packages/webpack-config-hot/src/hot.webpack.config.js
@@ -1,0 +1,13 @@
+import { HotModuleReplacementPlugin, NoErrorsPlugin } from 'webpack';
+
+export default function hotness({ hot = process.env.HOT }) {
+  return {
+    plugins: hot ? [
+      // Add webpack's HMR runtime.
+      new HotModuleReplacementPlugin(),
+
+      // Don't generate bundles with errors so HMR doesn't bomb the app.
+      new NoErrorsPlugin(),
+    ] : [ ],
+  };
+}

--- a/src/base.js
+++ b/src/base.js
@@ -10,6 +10,7 @@ import optimize from 'webpack-config-optimize';
 import stats from 'webpack-config-stats';
 import root from 'webpack-config-root';
 import dev from 'webpack-config-dev-server';
+import hot from 'webpack-config-hot';
 import sharp from 'webpack-config-sharp';
 
 export default function(config) {
@@ -24,6 +25,7 @@ export default function(config) {
     root,
     sourceMaps,
     dev,
+    hot,
     optimize
   );
 }


### PR DESCRIPTION
This allows for controlling the `hot` behaviour without using `webpack-udev-server`.
