### PR TITLE
Bump versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "webpack-config-babel": "^0.1.1",
     "webpack-config-build-info": "^0.1.0",
-    "webpack-config-dev-server": "^0.1.0",
+    "webpack-config-dev-server": "^0.2.0",
     "webpack-config-entry": "^0.1.0",
     "webpack-config-expose": "^0.1.1",
     "webpack-config-hot": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-config-metalab",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -d ./ ./src/",

--- a/packages/webpack-config-dev-server/package.json
+++ b/packages/webpack-config-dev-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-config-dev-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",


### PR DESCRIPTION
Mark the breaking split in `webpack-config-dev-server` with its own version and upgrade to use that.
