### PR TITLE
Update package dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *.log
 dist
 /*.js
+/*.map

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.2",
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "scripts": {
-    "prepublish": "./node_modules/.bin/babel -d ./ ./src/",
+    "prepublish": "./node_modules/.bin/babel  -s -d ./ ./src/",
     "lint": "./node_modules/.bin/eslint .",
     "test": "npm run lint"
   },
@@ -27,8 +27,8 @@
     "webpack": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1",
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0",
     "eslint": "^1.10.3",
     "eslint-config-metalab": "^1.0.0-rc.4",
     "eslint-plugin-filenames": "^0.2.0",

--- a/packages/webpack-config-babel/package.json
+++ b/packages/webpack-config-babel/package.json
@@ -6,16 +6,16 @@
   "license": "CC0-1.0",
   "main": "dist/babel.webpack.config.js",
   "scripts": {
-		"prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
-    "babel-loader": "^6.0.1"
+    "babel-loader": "^6.2.1"
   },
   "peerDependencies": {
     "webpack": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }

--- a/packages/webpack-config-build-info/package.json
+++ b/packages/webpack-config-build-info/package.json
@@ -6,13 +6,13 @@
   "license": "CC0-1.0",
   "main": "dist/build-info.webpack.config.js",
   "scripts": {
-		"prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "peerDependencies": {
     "webpack": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }

--- a/packages/webpack-config-dev-server/package.json
+++ b/packages/webpack-config-dev-server/package.json
@@ -6,14 +6,14 @@
   "license": "CC0-1.0",
   "main": "dist/dev-server.webpack.config.js",
   "scripts": {
-    "prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "peerDependencies": {
     "webpack": "*",
     "webpack-udev-server": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }

--- a/packages/webpack-config-entry/package.json
+++ b/packages/webpack-config-entry/package.json
@@ -6,7 +6,7 @@
   "license": "CC0-1.0",
   "main": "dist/entry.webpack.config.js",
   "scripts": {
-		"prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
     "find-nearest-file": "1.0.0"
@@ -15,7 +15,7 @@
     "webpack": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }

--- a/packages/webpack-config-env/package.json
+++ b/packages/webpack-config-env/package.json
@@ -6,13 +6,13 @@
   "license": "CC0-1.0",
   "main": "dist/env.webpack.config.js",
   "scripts": {
-		"prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "peerDependencies": {
     "webpack": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }

--- a/packages/webpack-config-expose/package.json
+++ b/packages/webpack-config-expose/package.json
@@ -6,7 +6,7 @@
   "license": "CC0-1.0",
   "main": "dist/expose.webpack.config.js",
   "scripts": {
-		"prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
     "resolve": "^1.1.6",
@@ -16,7 +16,7 @@
     "webpack": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }

--- a/packages/webpack-config-hot/package.json
+++ b/packages/webpack-config-hot/package.json
@@ -6,14 +6,14 @@
   "license": "CC0-1.0",
   "main": "dist/hot.webpack.config.js",
   "scripts": {
-    "prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "peerDependencies": {
     "webpack": "*",
     "webpack-udev-server": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }

--- a/packages/webpack-config-json/package.json
+++ b/packages/webpack-config-json/package.json
@@ -6,7 +6,7 @@
   "license": "CC0-1.0",
   "main": "dist/json.webpack.config.js",
   "scripts": {
-		"prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
     "json5-loader": "^0.6.0"
@@ -15,7 +15,7 @@
     "webpack": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }

--- a/packages/webpack-config-optimize/package.json
+++ b/packages/webpack-config-optimize/package.json
@@ -6,13 +6,13 @@
   "license": "CC0-1.0",
   "main": "dist/optimize.webpack.config.js",
   "scripts": {
-		"prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "peerDependencies": {
     "webpack": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }

--- a/packages/webpack-config-postcss/package.json
+++ b/packages/webpack-config-postcss/package.json
@@ -6,7 +6,7 @@
   "license": "CC0-1.0",
   "main": "dist/postcss.webpack.config.js",
   "scripts": {
-		"prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
     "autoprefixer": "^6.0.3",
@@ -14,15 +14,15 @@
     "postcss-import": "^7.1.0",
     "postcss-require": "^0.1.0",
     "precss": "^1.3.0",
-    "postcss-loader": "^0.7.0",
+    "postcss-loader": "^0.8.0",
     "style-loader": "^0.13.0",
-    "css-loader": "^0.21.0"
+    "css-loader": "^0.23.1"
   },
   "peerDependencies": {
     "postcss": ">=5.0.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }

--- a/packages/webpack-config-postcss/src/postcss.webpack.config.js
+++ b/packages/webpack-config-postcss/src/postcss.webpack.config.js
@@ -76,22 +76,22 @@ module.exports = function postcss({ target, postcss = [] }) {
       } ],
     },
 
-    postcss() {
+    postcss(webpack) {
       return [
         cssimport({
           // Make webpack acknowledge imported files.
-          onImport: files => files.forEach(this.addDependency),
-          resolve: (id, { basedir }) => this.resolveSync(basedir, id),
+          onImport: files => files.forEach(dep => webpack.addDependency(dep)),
+          resolve: (id, { basedir }) => webpack.resolveSync(basedir, id),
         }),
         constants({
           require: (request, _, done) => {
-            this.loadModule(request, (err, source) => {
+            webpack.loadModule(request, (err, source) => {
               if (err) {
                 done(err);
               } else {
                 let result = null;
                 try {
-                  result = this.exec(source, request);
+                  result = webpack.exec(source, request);
                   // interop for ES6 modules
                   if (result.__esModule && result.default) {
                     result = result.default;
@@ -108,9 +108,7 @@ module.exports = function postcss({ target, postcss = [] }) {
           },
         }),
         precss,
-        // this::postcss() refs the global function; thanks babel! :|
-        // so using `.call` for now.
-        ...(Array.isArray(postcss) ? postcss : postcss.call(this)),
+        ...(Array.isArray(postcss) ? postcss : postcss(webpack)),
         autoprefixer({
           browsers: [ 'last 2 versions' ],
         }),

--- a/packages/webpack-config-root/package.json
+++ b/packages/webpack-config-root/package.json
@@ -6,13 +6,13 @@
   "license": "CC0-1.0",
   "main": "dist/root.webpack.config.js",
   "scripts": {
-		"prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "peerDependencies": {
     "webpack": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }

--- a/packages/webpack-config-sharp/package.json
+++ b/packages/webpack-config-sharp/package.json
@@ -6,7 +6,7 @@
   "license": "CC0-1.0",
   "main": "dist/sharp.webpack.config.js",
   "scripts": {
-    "prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
     "sharp-loader": "^0.2.1",
@@ -16,7 +16,7 @@
     "webpack": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }

--- a/packages/webpack-config-source-maps/package.json
+++ b/packages/webpack-config-source-maps/package.json
@@ -6,14 +6,14 @@
   "license": "CC0-1.0",
   "main": "dist/source-maps.webpack.config.js",
   "scripts": {
-		"prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "peerDependencies": {
     "webpack": "*",
     "source-map-support": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }

--- a/packages/webpack-config-stats/package.json
+++ b/packages/webpack-config-stats/package.json
@@ -6,16 +6,16 @@
   "license": "CC0-1.0",
   "main": "dist/stats.webpack.config.js",
   "scripts": {
-		"prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
-    "stats-webpack-plugin": "^0.2.2"
+    "stats-webpack-plugin": "^0.3.0"
   },
   "peerDependencies": {
     "webpack": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }

--- a/packages/webpack-config-vendor/package.json
+++ b/packages/webpack-config-vendor/package.json
@@ -6,7 +6,7 @@
   "license": "CC0-1.0",
   "main": "dist/vendor.webpack.config.js",
   "scripts": {
-		"prepublish": "./node_modules/.bin/babel -d dist src"
+    "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
     "webpack-split-by-path": "^0.0.6",
@@ -16,7 +16,7 @@
     "webpack": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-preset-metalab": "^0.1.1"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0"
   }
 }


### PR DESCRIPTION
The new babel preset fixes a bunch of branches essentially never being taken for production code (due to environment variables being inlined). The postcss update just requires a slightly different calling convention. Also add sourcemaps because they are great.

/cc @nealgranger 
