### PR TITLE
Change to proper composition mechanism.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,29 @@ Just some handy [webpack] configuration generating functions.
 
 If your [webpack] configuration is large, unwieldy and/or confusing it's time to think about breaking it apart with [webpack-partial]. Partials are functions that take as input an existing webpack configuration and give as output a new webpack configuration. The modules here are simply preconfigured partials to do a lot of the heavy lifting for you.
 
-First install [webpack-partial]:
+First install some partials:
 
 ```sh
-npm install --save webpack-partial
+npm install --save webpack-config-entry webpack-config-babel
 ```
 
-Then create yourself a `webpack.config.js`:
+Then create yourself a `webpack.config.babel.js`:
 
 ```javascript
-// The magic.
-import partial from 'webpack-partial';
+import compose from 'lodash/flowRight';
 
 // Import useful partials.
 import entry from 'webpack-config-entry';
 import babel from 'webpack-config-babel';
 
-// Setting up webpack has never been this fast.
-export default partial(
-  { entry: 'foo.js' },
-  entry,
-  babel
+const createConfig = compose(
+  babel,
+  entry
 );
-```
 
-**IMPORTANT**: Right now these are ES6 modules _only_ meaning you have to `import` with something like babel or use `interop-require`.
+// Setting up webpack has never been this fast.
+export default createConfig({ entry: 'foo.js' });
+```
 
 **IMPORTANT**: If you're adding your own partials that include a `loader` reference you must use `require.resolve` on it for `npm@2`.
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "npm run lint"
   },
   "dependencies": {
+    "lodash": "^4.0.0",
     "webpack-config-babel": "^0.1.1",
     "webpack-config-build-info": "^0.1.0",
     "webpack-config-dev-server": "^0.2.0",

--- a/packages/webpack-config-babel/package.json
+++ b/packages/webpack-config-babel/package.json
@@ -4,12 +4,12 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/babel.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
-    "babel-loader": "^6.2.1"
+    "babel-loader": "^6.2.1",
+    "webpack-partial": "^1.0.0"
   },
   "peerDependencies": {
     "webpack": "*"

--- a/packages/webpack-config-babel/package.json
+++ b/packages/webpack-config-babel/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/babel.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-babel/src/babel.webpack.config.js
+++ b/packages/webpack-config-babel/src/babel.webpack.config.js
@@ -1,6 +1,8 @@
+import partial from 'webpack-partial';
 
-export default function babel({ babel }) {
-  return {
+export default function babel(config) {
+  const { babel } = config;
+  return partial(config, {
     module: {
       loaders: [ {
         name: 'babel',
@@ -10,5 +12,5 @@ export default function babel({ babel }) {
         query: babel,
       } ],
     },
-  };
+  });
 }

--- a/packages/webpack-config-build-info/package.json
+++ b/packages/webpack-config-build-info/package.json
@@ -4,7 +4,6 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/build-info.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
@@ -14,5 +13,8 @@
   "devDependencies": {
     "babel-cli": "^6.4.5",
     "babel-preset-metalab": "^0.2.0"
+  },
+  "dependencies": {
+    "webpack-partial": "^1.0.0"
   }
 }

--- a/packages/webpack-config-build-info/package.json
+++ b/packages/webpack-config-build-info/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/build-info.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-build-info/src/build-info.webpack.config.js
+++ b/packages/webpack-config-build-info/src/build-info.webpack.config.js
@@ -1,4 +1,5 @@
 import { DefinePlugin } from 'webpack';
+import partial from 'webpack-partial';
 import path from 'path';
 import fs from 'fs';
 import { execFileSync } from 'child_process';
@@ -20,7 +21,9 @@ function pkg(root) {
   return JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
 }
 
-export default function buildInfo({ context }) {
+export default function buildInfo(config) {
+  const { context } = config;
+
   // TODO: Any other useful information?
 
   // SOURCE_VERSION is set by Heroku. Can possibly be used by other build
@@ -30,7 +33,7 @@ export default function buildInfo({ context }) {
     'unknown';
   const version = pkg(context).version;
 
-  return {
+  return partial(config, {
     plugins: [
       new DefinePlugin({
         BUILD_COMMIT: JSON.stringify(commit),
@@ -38,5 +41,5 @@ export default function buildInfo({ context }) {
         BUILD_DATE: JSON.stringify(Date.now()),
       }),
     ],
-  };
+  });
 }

--- a/packages/webpack-config-dev-server/package.json
+++ b/packages/webpack-config-dev-server/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/dev-server.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-dev-server/package.json
+++ b/packages/webpack-config-dev-server/package.json
@@ -4,7 +4,6 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/dev-server.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
@@ -15,5 +14,8 @@
   "devDependencies": {
     "babel-cli": "^6.4.5",
     "babel-preset-metalab": "^0.2.0"
+  },
+  "dependencies": {
+    "webpack-partial": "^1.0.0"
   }
 }

--- a/packages/webpack-config-dev-server/src/dev-server.webpack.config.js
+++ b/packages/webpack-config-dev-server/src/dev-server.webpack.config.js
@@ -1,3 +1,4 @@
+import partial from 'webpack-partial';
 import { runtime } from 'webpack-udev-server';
 
 function inject(entries, module) {
@@ -15,19 +16,20 @@ function inject(entries, module) {
   throw new TypeError();
 }
 
-export default function devServer({ entry, target, hot = process.env.HOT }) {
+export default function devServer(config) {
+  const { entry, target, hot = process.env.HOT } = config;
   const env = process.env.NODE_ENV || 'development';
 
   // Don't use for anything but development.
   if (env !== 'development') {
-    return { };
+    return config;
   }
 
   // Rewrite all the entry points to include HMR code.
-  return {
+  return partial(config, {
     entry: inject(
       entry,
       runtime({ target, hot })
     ),
-  };
+  });
 }

--- a/packages/webpack-config-entry/package.json
+++ b/packages/webpack-config-entry/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/entry.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-entry/package.json
+++ b/packages/webpack-config-entry/package.json
@@ -4,12 +4,12 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/entry.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
-    "find-nearest-file": "1.0.0"
+    "find-nearest-file": "1.0.0",
+    "webpack-partial": "^1.0.0"
   },
   "peerDependencies": {
     "webpack": "*"

--- a/packages/webpack-config-entry/src/entry.webpack.config.js
+++ b/packages/webpack-config-entry/src/entry.webpack.config.js
@@ -1,4 +1,4 @@
-
+import partial from 'webpack-partial';
 import nearest from 'find-nearest-file';
 import path from 'path';
 import { optimize } from 'webpack';
@@ -6,8 +6,9 @@ import { optimize } from 'webpack';
 // No matter where we are, locate the canonical root of the project.
 const root = path.dirname(nearest('package.json'));
 
-export default function({ target, name }) {
-  return {
+export default function(config) {
+  const { target, name } = config;
+  return partial(config, {
     entry: {
       [name]: path.join(root, 'entry', `${name}.entry.js`),
     },
@@ -22,5 +23,5 @@ export default function({ target, name }) {
     plugins: [
       new optimize.OccurenceOrderPlugin(true),
     ],
-  };
+  });
 }

--- a/packages/webpack-config-env/package.json
+++ b/packages/webpack-config-env/package.json
@@ -4,7 +4,6 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/env.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
@@ -14,5 +13,8 @@
   "devDependencies": {
     "babel-cli": "^6.4.5",
     "babel-preset-metalab": "^0.2.0"
+  },
+  "dependencies": {
+    "webpack-partial": "^1.0.0"
   }
 }

--- a/packages/webpack-config-env/package.json
+++ b/packages/webpack-config-env/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/env.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-env/src/env.webpack.config.js
+++ b/packages/webpack-config-env/src/env.webpack.config.js
@@ -1,17 +1,13 @@
-
+import partial from 'webpack-partial';
 import { EnvironmentPlugin } from 'webpack';
 
-export default function env() {
-  // Use bluebird long traces for development and testing
-  // See: https://github.com/petkaantonov/bluebird#error-handling
-  process.env.BLUEBIRD_DEBUG = env.NODE_ENV !== 'production';
-
-  return {
+export default function env(config) {
+  return partial(config, {
     plugins: [
       // Export `process.env` to the app being built. Optimize your code by
       // checking `NODE_ENV` and set things like config variables (e.g.
       // `API_URL`).
       new EnvironmentPlugin(Object.keys(process.env)),
     ],
-  };
+  });
 }

--- a/packages/webpack-config-expose/package.json
+++ b/packages/webpack-config-expose/package.json
@@ -4,13 +4,13 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/expose.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
+    "expose-loader": "^0.7.0",
     "resolve": "^1.1.6",
-    "expose-loader": "^0.7.0"
+    "webpack-partial": "^1.0.0"
   },
   "peerDependencies": {
     "webpack": "*"

--- a/packages/webpack-config-expose/package.json
+++ b/packages/webpack-config-expose/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/expose.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-expose/src/expose.webpack.config.js
+++ b/packages/webpack-config-expose/src/expose.webpack.config.js
@@ -1,8 +1,9 @@
-
+import partial from 'webpack-partial';
 import resolve from 'resolve';
 
-export default function expose({ expose = [], context }) {
-  return {
+export default function expose(config) {
+  const { expose = [], context } = config;
+  return partial(config, {
     module: {
       loaders: Object.keys(expose).map(module => {
         return {
@@ -14,5 +15,5 @@ export default function expose({ expose = [], context }) {
         };
       }),
     },
-  };
+  });
 }

--- a/packages/webpack-config-hot/package.json
+++ b/packages/webpack-config-hot/package.json
@@ -4,7 +4,6 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/hot.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
@@ -15,5 +14,8 @@
   "devDependencies": {
     "babel-cli": "^6.4.5",
     "babel-preset-metalab": "^0.2.0"
+  },
+  "dependencies": {
+    "webpack-partial": "^1.0.0"
   }
 }

--- a/packages/webpack-config-hot/package.json
+++ b/packages/webpack-config-hot/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/hot.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-hot/src/hot.webpack.config.js
+++ b/packages/webpack-config-hot/src/hot.webpack.config.js
@@ -1,7 +1,9 @@
+import partial from 'webpack-partial';
 import { HotModuleReplacementPlugin, NoErrorsPlugin } from 'webpack';
 
-export default function hotness({ hot = process.env.HOT }) {
-  return {
+export default function hotness(config) {
+  const { hot = process.env.HOT } = config;
+  return partial(config, {
     plugins: hot ? [
       // Add webpack's HMR runtime.
       new HotModuleReplacementPlugin(),
@@ -9,5 +11,5 @@ export default function hotness({ hot = process.env.HOT }) {
       // Don't generate bundles with errors so HMR doesn't bomb the app.
       new NoErrorsPlugin(),
     ] : [ ],
-  };
+  });
 }

--- a/packages/webpack-config-json/package.json
+++ b/packages/webpack-config-json/package.json
@@ -4,12 +4,12 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/json.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
-    "json5-loader": "^0.6.0"
+    "json5-loader": "^0.6.0",
+    "webpack-partial": "^1.0.0"
   },
   "peerDependencies": {
     "webpack": "*"

--- a/packages/webpack-config-json/package.json
+++ b/packages/webpack-config-json/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/json.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-json/src/json.webpack.config.js
+++ b/packages/webpack-config-json/src/json.webpack.config.js
@@ -1,6 +1,7 @@
+import partial from 'webpack-partial';
 
-export default function json5() {
-  return {
+export default function json5(config) {
+  return partial(config, {
     module: {
       loaders: [ {
         name: 'json5',
@@ -8,5 +9,5 @@ export default function json5() {
         loader: require.resolve('json5-loader'),
       } ],
     },
-  };
+  });
 }

--- a/packages/webpack-config-optimize/package.json
+++ b/packages/webpack-config-optimize/package.json
@@ -4,7 +4,6 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/optimize.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
@@ -14,5 +13,8 @@
   "devDependencies": {
     "babel-cli": "^6.4.5",
     "babel-preset-metalab": "^0.2.0"
+  },
+  "dependencies": {
+    "webpack-partial": "^1.0.0"
   }
 }

--- a/packages/webpack-config-optimize/package.json
+++ b/packages/webpack-config-optimize/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/optimize.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-optimize/src/optimize.webpack.config.js
+++ b/packages/webpack-config-optimize/src/optimize.webpack.config.js
@@ -1,8 +1,8 @@
-
+import partial from 'webpack-partial';
 import { optimize } from 'webpack';
 
-export default function optimizer() {
-  return {
+export default function optimizer(config) {
+  return partial(config, {
     plugins: process.env.NODE_ENV === 'production' ? [
       new optimize.DedupePlugin(),
       new optimize.UglifyJsPlugin({
@@ -11,5 +11,5 @@ export default function optimizer() {
         },
       }),
     ] : [],
-  };
+  });
 }

--- a/packages/webpack-config-postcss/package.json
+++ b/packages/webpack-config-postcss/package.json
@@ -4,19 +4,19 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/postcss.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
     "autoprefixer": "^6.0.3",
+    "css-loader": "^0.23.1",
     "extract-text-webpack-plugin": "^0.9.0",
     "postcss-import": "^7.1.0",
+    "postcss-loader": "^0.8.0",
     "postcss-require": "^0.1.0",
     "precss": "^1.3.0",
-    "postcss-loader": "^0.8.0",
     "style-loader": "^0.13.0",
-    "css-loader": "^0.23.1"
+    "webpack-partial": "^1.0.0"
   },
   "peerDependencies": {
     "postcss": ">=5.0.0"

--- a/packages/webpack-config-postcss/package.json
+++ b/packages/webpack-config-postcss/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/postcss.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-postcss/src/postcss.webpack.config.js
+++ b/packages/webpack-config-postcss/src/postcss.webpack.config.js
@@ -1,3 +1,4 @@
+import partial from 'webpack-partial';
 
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 
@@ -50,7 +51,8 @@ function loaders({ target, external, minimize, loader }) {
   return `${pack(cssLocals, config)}!${loader}`;
 }
 
-module.exports = function postcss({ target, postcss = [] }) {
+module.exports = function postcss(config) {
+  const { target, postcss = [] } = config;
   const env = process.env.NODE_ENV || 'development';
   const hot = process.env.HOT || false;
   const production = env === 'production';
@@ -62,7 +64,7 @@ module.exports = function postcss({ target, postcss = [] }) {
     throw new TypeError('`postcss` must be array or function!');
   }
 
-  return {
+  return partial(config, {
     // Module settings.
     module: {
       loaders: [ {
@@ -124,5 +126,5 @@ module.exports = function postcss({ target, postcss = [] }) {
         new ExtractTextPlugin('[name].css'),
       ] : [ ]),
     ],
-  };
+  });
 };

--- a/packages/webpack-config-root/package.json
+++ b/packages/webpack-config-root/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/root.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-root/package.json
+++ b/packages/webpack-config-root/package.json
@@ -4,7 +4,6 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/root.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
@@ -14,5 +13,8 @@
   "devDependencies": {
     "babel-cli": "^6.4.5",
     "babel-preset-metalab": "^0.2.0"
+  },
+  "dependencies": {
+    "webpack-partial": "^1.0.0"
   }
 }

--- a/packages/webpack-config-root/src/root.webpack.config.js
+++ b/packages/webpack-config-root/src/root.webpack.config.js
@@ -2,6 +2,7 @@ import partial from 'webpack-partial';
 import path from 'path';
 
 export default function root(config) {
+  const { context } = config;
   return partial(config, {
     resolve: {
       root: [

--- a/packages/webpack-config-root/src/root.webpack.config.js
+++ b/packages/webpack-config-root/src/root.webpack.config.js
@@ -1,12 +1,12 @@
-
+import partial from 'webpack-partial';
 import path from 'path';
 
-export default function root({ context }) {
-  return {
+export default function root(config) {
+  return partial(config, {
     resolve: {
       root: [
         path.join(context, 'src'),
       ],
     },
-  };
+  });
 }

--- a/packages/webpack-config-sharp/package.json
+++ b/packages/webpack-config-sharp/package.json
@@ -4,13 +4,13 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/sharp.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
+    "sharp": "^0.12.1",
     "sharp-loader": "^0.2.1",
-    "sharp": "^0.12.1"
+    "webpack-partial": "^1.0.0"
   },
   "peerDependencies": {
     "webpack": "*"

--- a/packages/webpack-config-sharp/package.json
+++ b/packages/webpack-config-sharp/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/sharp.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-sharp/src/sharp.webpack.config.js
+++ b/packages/webpack-config-sharp/src/sharp.webpack.config.js
@@ -1,6 +1,7 @@
+import partial from 'webpack-partial';
 
-export default function sharp() {
-  return {
+export default function sharp(config) {
+  return partial(config, {
     module: {
       loaders: [ {
         name: 'sharp',
@@ -24,5 +25,5 @@ export default function sharp() {
         },
       } ],
     },
-  };
+  });
 }

--- a/packages/webpack-config-source-maps/package.json
+++ b/packages/webpack-config-source-maps/package.json
@@ -4,7 +4,6 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/source-maps.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
@@ -15,5 +14,8 @@
   "devDependencies": {
     "babel-cli": "^6.4.5",
     "babel-preset-metalab": "^0.2.0"
+  },
+  "dependencies": {
+    "webpack-partial": "^1.0.0"
   }
 }

--- a/packages/webpack-config-source-maps/package.json
+++ b/packages/webpack-config-source-maps/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/source-maps.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-source-maps/src/source-maps.webpack.config.js
+++ b/packages/webpack-config-source-maps/src/source-maps.webpack.config.js
@@ -1,7 +1,8 @@
-
+import partial from 'webpack-partial';
 import { BannerPlugin, SourceMapDevToolPlugin } from 'webpack';
 
-export default function sourcemaps({ target }) {
+export default function sourcemaps(config) {
+  const { target } = config;
   const env = process.env.NODE_ENV || 'development';
   const inline = env !== 'production';
 
@@ -11,7 +12,7 @@ export default function sourcemaps({ target }) {
     return `${base}/[url]`;
   }
 
-  return {
+  return partial(config, {
     // Embed source map support for sane debugging. This kinda cheats by
     // writing source map hooks at the top of every entrypoint.
     plugins: [
@@ -28,5 +29,5 @@ export default function sourcemaps({ target }) {
         columns: true,
       }),
     ],
-  };
+  });
 }

--- a/packages/webpack-config-stats/package.json
+++ b/packages/webpack-config-stats/package.json
@@ -4,12 +4,12 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/stats.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
-    "stats-webpack-plugin": "^0.3.0"
+    "stats-webpack-plugin": "^0.3.0",
+    "webpack-partial": "^1.0.0"
   },
   "peerDependencies": {
     "webpack": "*"

--- a/packages/webpack-config-stats/package.json
+++ b/packages/webpack-config-stats/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/stats.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-stats/src/stats.webpack.config.js
+++ b/packages/webpack-config-stats/src/stats.webpack.config.js
@@ -2,7 +2,8 @@ import partial from 'webpack-partial';
 import StatsPlugin from 'stats-webpack-plugin';
 
 export default function stats(config) {
-  const config = {
+  const { stats } = config;
+  const options = {
     hash: true,
     assets: false,
     reasons: false,
@@ -12,7 +13,7 @@ export default function stats(config) {
   };
   return partial(config, {
     plugins: [
-      new StatsPlugin('stats.json', config),
+      new StatsPlugin('stats.json', options),
     ],
   });
 }

--- a/packages/webpack-config-stats/src/stats.webpack.config.js
+++ b/packages/webpack-config-stats/src/stats.webpack.config.js
@@ -1,7 +1,7 @@
-
+import partial from 'webpack-partial';
 import StatsPlugin from 'stats-webpack-plugin';
 
-export default function stats({ stats }) {
+export default function stats(config) {
   const config = {
     hash: true,
     assets: false,
@@ -10,9 +10,9 @@ export default function stats({ stats }) {
     source: false,
     ...stats,
   };
-  return {
+  return partial(config, {
     plugins: [
       new StatsPlugin('stats.json', config),
     ],
-  };
+  });
 }

--- a/packages/webpack-config-vendor/package.json
+++ b/packages/webpack-config-vendor/package.json
@@ -4,13 +4,13 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
-  "main": "dist/vendor.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },
   "dependencies": {
-    "webpack-split-by-path": "^0.0.6",
-    "runtime-webpack-plugin": "^0.1.0"
+    "runtime-webpack-plugin": "^0.1.0",
+    "webpack-partial": "^1.0.0",
+    "webpack-split-by-path": "^0.0.6"
   },
   "peerDependencies": {
     "webpack": "*"

--- a/packages/webpack-config-vendor/package.json
+++ b/packages/webpack-config-vendor/package.json
@@ -4,6 +4,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "repository": "izaakschroeder/webpack-config-metalab",
   "license": "CC0-1.0",
+  "main": "dist/vendor.webpack.config.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src"
   },

--- a/packages/webpack-config-vendor/src/vendor.webpack.config.js
+++ b/packages/webpack-config-vendor/src/vendor.webpack.config.js
@@ -1,10 +1,12 @@
+import partial from 'webpack-partial';
 import path from 'path';
 import RuntimePlugin from 'runtime-webpack-plugin';
 import SplitByPathPlugin from 'webpack-split-by-path';
 
-export default function({ context, target }) {
+export default function(config) {
+  const { context, target } = config;
   const isNode = target === 'node';
-  return {
+  return partial({
     externals: isNode ? [ (context, request, cb) => {
 			// TODO: Make this work properly.
       if (/^[a-z\-0-9]+$/.test(request)) {
@@ -21,5 +23,5 @@ export default function({ context, target }) {
       } ]),
       new RuntimePlugin('init'),
     ] : [ ],
-  };
+  });
 }

--- a/src/base.js
+++ b/src/base.js
@@ -18,6 +18,7 @@ export default compose(
   sourceMaps,
   root,
   stats,
+  sharp,
   json,
   buildInfo,
   babel,

--- a/src/base.js
+++ b/src/base.js
@@ -1,6 +1,4 @@
-
-import partial from 'webpack-partial';
-
+import compose from 'lodash/flowRight';
 import entry from 'webpack-config-entry';
 import buildInfo from 'webpack-config-build-info';
 import sourceMaps from 'webpack-config-source-maps';
@@ -13,19 +11,15 @@ import dev from 'webpack-config-dev-server';
 import hot from 'webpack-config-hot';
 import sharp from 'webpack-config-sharp';
 
-export default function(config) {
-  return partial(
-    config,
-    entry,
-    babel,
-    buildInfo,
-    json,
-    sharp,
-    stats,
-    root,
-    sourceMaps,
-    dev,
-    hot,
-    optimize
-  );
-}
+export default compose(
+  optimize,
+  hot,
+  dev,
+  sourceMaps,
+  root,
+  stats,
+  json,
+  buildInfo,
+  babel,
+  entry
+);

--- a/src/client.js
+++ b/src/client.js
@@ -1,20 +1,8 @@
-import partial from 'webpack-partial';
-
+import compose from 'lodash/flowRight';
 import postcss from 'webpack-config-postcss';
 import expose from 'webpack-config-expose';
 
-import base from './base';
-
-export default function(config) {
-  return partial(
-    config,
-    base,
-    postcss,
-    {
-      expose: {
-        react: 'React',
-      },
-    },
-    expose
-  );
-}
+export default compose(
+  expose,
+  postcss
+);

--- a/src/server.js
+++ b/src/server.js
@@ -1,13 +1,6 @@
-import partial from 'webpack-partial';
-
+import compose from 'lodash/flowRight';
 import postcss from 'webpack-config-postcss';
 
-import base from './base';
-
-export default function(config) {
-  return partial(
-    config,
-    base,
-    postcss
-  );
-}
+export default compose(
+  postcss
+);


### PR DESCRIPTION
Previously all partials were functions that accepted a full webpack configuration as input and returned a partial webpack configuration to be merged via `webpack-partial`. Change to use a real composition mechanism, whereby partials take a full webpack configuration as input and return a full webpack configuration as output. This allows them to choose their merge mechanism (e.g. `webpack-partial`) and to be chained together with `compose`.

Previously all partials got their configuration straight from the webpack object. Now it's possible to send them through as part of a higher-order function. e.g. `babel` can become `babel(babelOpts)`. This obviously is a fairly API-breaking change.

``` javascript
partial(webpackConfig, partialA, partialB);
```

now can become:

``` javascript
compose(partialB, higherOrderPartialA())(webpackConfig);
```
